### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/prismacloud.yml
+++ b/.github/workflows/prismacloud.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run Prisma Cloud IaC Scan to check 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         
       - name: Set global git configs
         run: |
@@ -24,7 +24,7 @@ jobs:
           GH_TOKEN: ${{ secrets.MY_GITHUB_PAT }}
         
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
           log_level: debug
           
       - name: Prisma - Generate SARIF report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: SARIF results
           path: results.sarif

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         
       - name: Set global git configs
         run: |
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ secrets.MY_GITHUB_PAT }}
         
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions