### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/prismacloud.yml
+++ b/.github/workflows/prismacloud.yml
@@ -74,7 +74,7 @@ jobs:
 
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3
         if: success() || failure()
         with:
           sarif_file: results.sarif

--- a/.github/workflows/prismacloud.yml
+++ b/.github/workflows/prismacloud.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run Prisma Cloud IaC Scan to check 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         
       - name: Set global git configs
         run: |
@@ -24,7 +24,7 @@ jobs:
           GH_TOKEN: ${{ secrets.MY_GITHUB_PAT }}
         
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
           log_level: debug
           
       - name: Prisma - Generate SARIF report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: SARIF results
           path: results.sarif
@@ -74,7 +74,7 @@ jobs:
 
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         if: success() || failure()
         with:
           sarif_file: results.sarif

--- a/.github/workflows/prismacloud.yml
+++ b/.github/workflows/prismacloud.yml
@@ -50,7 +50,7 @@ jobs:
           log_level: debug
           
       - name: Prisma - Generate SARIF report
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF results
           path: results.sarif

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -50,7 +50,7 @@ jobs:
           sarif_file: tfsec.sarif         
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif  

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         
       - name: Set global git configs
         run: |
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ secrets.MY_GITHUB_PAT }}
         
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
           sarif_file: tfsec.sarif         
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif  


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also includes updates to `actions/upload-artifact` `v2` -> `v4` due to deprecation. And `github/codeql-action/upload-sarif` from `v2` -> `v3` due to https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/